### PR TITLE
destroy views on unmount

### DIFF
--- a/android/src/main/java/com/ammarahmed/rnadmob/nativeads/RNAdMobNativeViewManager.java
+++ b/android/src/main/java/com/ammarahmed/rnadmob/nativeads/RNAdMobNativeViewManager.java
@@ -217,6 +217,9 @@ public class RNAdMobNativeViewManager extends ViewGroupManager<RNNativeAdWrapper
         if (nativeAdView.unifiedNativeAd != null){
             nativeAdView.unifiedNativeAd.destroy();
         }
+	if (nativeAdView.nativeAdView != null){
+            nativeAdView.nativeAdView.destroy();
+        }
     }
 
 

--- a/android/src/main/java/com/ammarahmed/rnadmob/nativeads/RNNativeAdWrapper.java
+++ b/android/src/main/java/com/ammarahmed/rnadmob/nativeads/RNNativeAdWrapper.java
@@ -145,6 +145,8 @@ public class RNNativeAdWrapper extends LinearLayout {
         }
     }
 
+    private Runnable runnable;
+
     private void setNativeAdToJS(UnifiedNativeAd nativeAd) {
         try {
             WritableMap args = Arguments.createMap();
@@ -178,12 +180,13 @@ public class RNNativeAdWrapper extends LinearLayout {
 
         }
         if (handler != null) {
-            handler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    loadAd();
-                }
-            }, adRefreshInterval);
+            runnable = new Runnable() {
+               @Override
+               public void run() {
+                   loadAd();
+               }
+            };
+            handler.postDelayed(runnable, adRefreshInterval);
         }
     }
 
@@ -271,14 +274,10 @@ public class RNNativeAdWrapper extends LinearLayout {
         post(measureAndLayout);
     }
 
-
     public void removeHandler() {
         if (handler != null) {
-            handler.removeCallbacks(null);
+            handler.removeCallbacks(runnable);
             handler = null;
         }
-
     }
-
-
 }


### PR DESCRIPTION
Thanks for your package. It really helps us in our project.

This PR fixes memory leak we are seeing in our stress test, which is an auto navigation between different pages of our app, some of which have 1 or few native ads in flat lists, section lists, and scroll views.

Here is also a possibly related error captured by human testers:
```
java.lang.IllegalStateException Too many receivers, total of 1000, registered for pid: 1458, callerPackage: ...
    Parcel.java:2096 android.os.Parcel.createException
    Parcel.java:2056 android.os.Parcel.readException
    Parcel.java:2004 android.os.Parcel.readException
    IActivityManager.java:5595 android.app.IActivityManager$Stub$Proxy.registerReceiver
    ContextImpl.java:1589 android.app.ContextImpl.registerReceiverInternal
    ContextImpl.java:1550 android.app.ContextImpl.registerReceiver
    ContextImpl.java:1538 android.app.ContextImpl.registerReceiver
    ContextWrapper.java:641 android.content.ContextWrapper.registerReceiver
    :com.google.android.gms.policy_ads_fdr_dynamite@21829057@21829057.311174395.311174395:7 com.google.android.gms.ads.internal.util.br.a
    :com.google.android.gms.policy_ads_fdr_dynamite@21829057@21829057.311174395.311174395:6 com.google.android.gms.ads.internal.activeview.ac.a
    :com.google.android.gms.policy_ads_fdr_dynamite@21829057@21829057.311174395.311174395 com.google.android.gms.ads.internal.activeview.ac.onViewAttachedToWindow
    View.java:21318 android.view.View.dispatchAttachedToWindow
    ViewGroup.java:4239 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:4246 android.view.ViewGroup.dispatchAttachedToWindow
    ViewGroup.java:6001 android.view.ViewGroup.addViewInner
    ViewGroup.java:5934 android.view.ViewGroup.addViewInLayout
    ReactViewGroup.java:380 com.facebook.react.views.view.ReactViewGroup.updateSubviewClipStatus
    ReactViewGroup.java:420 com.facebook.react.views.view.ReactViewGroup.updateSubviewClipStatus
    ReactViewGroup.java:53 com.facebook.react.views.view.ReactViewGroup.access$000
    ReactViewGroup.java:94 com.facebook.react.views.view.ReactViewGroup$ChildrenLayoutChangeListener.onLayoutChange
    View.java:23771 android.view.View.layout
    ViewGroup.java:7277 android.view.ViewGroup.layout
    NativeViewHierarchyManager.java:251 com.facebook.react.uimanager.NativeViewHierarchyManager.updateLayout
    NativeViewHierarchyManager.java:219 com.facebook.react.uimanager.NativeViewHierarchyManager.updateLayout
    UIViewOperationQueue.java:154 com.facebook.react.uimanager.UIViewOperationQueue$UpdateLayoutOperation.execute
    UIViewOperationQueue.java:779 com.facebook.react.uimanager.UIViewOperationQueue$1.run
    UIViewOperationQueue.java:888 com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches
    UIViewOperationQueue.java:42 com.facebook.react.uimanager.UIViewOperationQueue.access$2200
    UIViewOperationQueue.java:948 com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.doFrameGuarded
    GuardedFrameCallback.java:28 com.facebook.react.uimanager.GuardedFrameCallback.doFrame
    ReactChoreographer.java:174 com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame
    ChoreographerCompat.java:84 com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame
    Choreographer.java:997 android.view.Choreographer$CallbackRecord.run
    Choreographer.java:797 android.view.Choreographer.doCallbacks
    Choreographer.java:728 android.view.Choreographer.doFrame
    Choreographer.java:984 android.view.Choreographer$FrameDisplayEventReceiver.run
    Handler.java:883 android.os.Handler.handleCallback
    Handler.java:100 android.os.Handler.dispatchMessage
    Looper.java:237 android.os.Looper.loop
    ActivityThread.java:8016 android.app.ActivityThread.main
    Method.java:-2 java.lang.reflect.Method.invoke
    RuntimeInit.java:493 com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run
    ZygoteInit.java:1076 com.android.internal.os.ZygoteInit.main

Caused by: android.os.RemoteException Remote stack trace:
	at com.android.server.am.ActivityManagerService.registerReceiver(ActivityManagerService.java:17136)
	at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:2269)
	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:3359)
	at android.os.Binder.execTransactInternal(Binder.java:1021)
	at android.os.Binder.execTransact(Binder.java:994)
 
    unknown file unknown method
```

Also we are investigating another possible leak caused by low values of refresh interval, e.g. 1 minute.
