### PR TITLE
ImageProps type fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -338,11 +338,12 @@ return: `boolean`
   /**
    * If you want to explicitly show only Images and no video etc, use ImageView.
    */
-  export function ImageView(props: ImageProps): JSX.Element;
+  export function ImageView(props: Partial<ImageProps>): JSX.Element;
+  
   /**
    * Icon/Logo of the adveriser shown inside this view
    */
-  export function IconView(props: ImageProps): JSX.Element;
+  export function IconView(props: Partial<ImageProps>): JSX.Element;
 
   /**
    * If the ad has images or video content. It will be loaded inside the MediaView.


### PR DESCRIPTION
Hey man!

First, thanks for this amazing package. You're doing a really good and solid job here.

I think we should use a partial implementation for ImageProps because IconView sometimes won't have a source:

```typescript
<IconView
  style={{
    width: '100%',
    height: 90,
  }}
/>
```

Above example will generate the following issue with the current types:

> TS2741: Property 'source' is missing in type '{ style: { width: string; height: number; }; }' but required in type 'ImageProps'.

Using a Partial implementation fix this problem.

Let me know what do you think about it!