### PR TITLE
fix: icon name issue

### DIFF
--- a/src/StarView.js
+++ b/src/StarView.js
@@ -45,7 +45,7 @@ export default function StarView({
   size = 15,
   iconSet = 'MaterialCommunityIcons',
   fullIcon = 'star',
-  halfIcon = 'star-half-full',
+  halfIcon = 'star-half',
   emptyIcon = 'star-outline',
   passRef,
   ...passThroughProps


### PR DESCRIPTION
This fixes the issue with star rating half icon not showing correctly issue
![Screenshot 2020-11-23 at 3 29 02 PM](https://user-images.githubusercontent.com/43908929/99949243-b46d2080-2da0-11eb-90b0-e5305c788d20.png)
![Screenshot 2020-11-23 at 3 25 18 PM](https://user-images.githubusercontent.com/43908929/99949250-b636e400-2da0-11eb-9288-3499af2b254e.png)

