### PR TITLE
add prompise to setRequestConfiguration() and use activity context if possible

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 repositories {

--- a/index.d.ts
+++ b/index.d.ts
@@ -262,7 +262,7 @@ declare module "react-native-admob-native-ads" {
     *
     */
 
-    setRequestConfiguration: (config: Partial<AdManagerConfiguration>) => {},
+    setRequestConfiguration: (config: Partial<AdManagerConfiguration>) => Promise<object>;
 
     /**
      * Check if the current device is registered as a test device to show test ads.

--- a/src/AdManager.js
+++ b/src/AdManager.js
@@ -2,8 +2,8 @@ import {NativeModules} from 'react-native';
 
 const RNAdmobNativeAdsManager = NativeModules.RNAdmobNativeAdsManager;
 
-function setRequestConfiguration(config) {
-  RNAdmobNativeAdsManager.setRequestConfiguration(config);
+async function setRequestConfiguration(config) {
+  return RNAdmobNativeAdsManager.setRequestConfiguration(config);
 }
 
 function isTestDevice() {


### PR DESCRIPTION
Fixes #151 
- Users can now wait for configuration to be done. The returned promise has debug information about the mediation networks.
- Use activity context if possible. Fixes issue with MoPub.

PS: In case you are interested, take a look at https://github.com/ammarahm-ed/react-native-admob-native-ads/compare/master...halaei:update-admob-api?expand=1
In this branch Younse and I updated Admob SDK version to 20.+. Unfortunately, it can't be easily merged here because we changed a few things regarding preloading ads.