### PR TITLE
[iOS] Fix re-register direct event as bubbling event

### DIFF
--- a/ios/RNGADMediaView.h
+++ b/ios/RNGADMediaView.h
@@ -10,12 +10,12 @@
 @property (nonatomic) BOOL *pause;
 @property (nonatomic) BOOL *muted;
 
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoPlay;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoPause;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoMute;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoStart;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoEnd;
-@property (nonatomic, copy) RCTBubblingEventBlock onVideoProgress;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoPlay;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoPause;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoMute;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoStart;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoEnd;
+@property (nonatomic, copy) RCTDirectEventBlock onVideoProgress;
 
 - (void)getCurrentProgress;
 


### PR DESCRIPTION
Fixes #161, #170

Currently the react-native-admob-native-ads uses "RCTBubblingEventBlock" which causes conflicts with the library react-native-video, which is using "RCTDirectEventBlock" for event blocking. This can be fixed by using the same blocking type for both libraries.

https://github.com/react-native-video/react-native-video/issues/1850