### PR TITLE
Remove warnning 'EventEmitter.removeListener('change', ...)'

### DIFF
--- a/example/src/AdView.js
+++ b/example/src/AdView.js
@@ -108,8 +108,10 @@ export const AdView = React.memo(({index, media, type, loadOnMount = true}) => {
      *
      * [STEP III] We will subscribe to onViewableItemsChanged event in all AdViews in the List.
      */
+    let onViewableItemsChangedHandler;
+    
     if (!loadOnMount) {
-      DeviceEventEmitter.addListener(
+     onViewableItemsChangedHandler = DeviceEventEmitter.addListener(
         Events.onViewableItemsChanged,
         onViewableItemsChanged,
       );
@@ -117,10 +119,7 @@ export const AdView = React.memo(({index, media, type, loadOnMount = true}) => {
 
     return () => {
       if (!loadOnMount) {
-        DeviceEventEmitter.removeListener(
-          Events.onViewableItemsChanged,
-          onViewableItemsChanged,
-        );
+        onViewableItemsChangedHandler.remove();
       }
     };
   }, [index, loadOnMount, loaded]);


### PR DESCRIPTION
EventEmitter.removeListener('change', ...): Method has been deprecated

thanks.

-reference link
https://github.com/react-navigation/react-navigation/issues/9894