### PR TITLE
Suggest using empty array instead of undefined in dispatchViewManagerCommand


### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ export class NativeAdView extends Component {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.nativeAdRef),
       UIManager.getViewManagerConfig("RNGADNativeView").Commands.loadAd,
-      undefined
+      []
     );
   };
 


### PR DESCRIPTION
**Hello,**
@ammarahm-ed 

![Screenshot_1731261167](https://github.com/user-attachments/assets/f939da54-790a-4fdb-9786-db994c8a6525)

While working with UIManager.dispatchViewManagerCommand in React Native, I noticed an issue where passing undefined as the commandArgs parameter leads to an UnexpectedNativeTypeException.

 From what I understand, this is because commandArgs is expected to be an optional Array<any> according to its type definition. Therefore, I believe that using an empty array [] instead of undefined might be a more suitable approach.



### Problem Description:
Currently, the loadAd function passes undefined for commandArgs:

`loadAd = () => {
  UIManager.dispatchViewManagerCommand(
    findNodeHandle(this.nativeAdRef),
    UIManager.getViewManagerConfig("RNGADNativeView").Commands.loadAd,
    undefined
  );
};
`

### Suggested Change:
`loadAd = () => {
  UIManager.dispatchViewManagerCommand(
    findNodeHandle(this.nativeAdRef),
    UIManager.getViewManagerConfig("RNGADNativeView").Commands.loadAd,
    [] // Using an empty array instead of undefined
  );
};
`

### Reasoning for the Suggestion:
This approach can prevent the UnexpectedNativeTypeException that occurs when undefined is passed.

Aligning the parameter type with the expected definition might reduce potential errors and make the code safer.

I hope this suggestion can be helpful for the project. Please feel free to share any feedback or if further discussion is needed!

Thank you
